### PR TITLE
Add multiple replicas

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,42 @@
+# Gunicorn Worker, Container Replica & Database Connection Comparison
+
+This repo is put together to explore the performance tradeoffs between running a Flask app with multiple workers vs. a single worker per container, while also varying things like the database connection pools, and the number of containers.
+
+## Prerequisites
+
+This setup requires:
+
+- Docker & docker compose
+- k6 load testing tool
+
+Docker should already be installed via your engineering laptop setup, and k6 can be installed with brew.
+
+```
+brew install k6
+```
+
+## Context
+
+This setup uses docker compose to run a simple Flask app via Gunicorn that simulates I/O heavy workloads, a MySQL database, and an nginx container to act as a load balancer between 1-2 replicas of the Flask app.
+
+K6 is then used to throw traffic at the app, so we can measure the performance difference between different configurations. The primary areas of experimentation are currently:
+
+- number of Gunicorn workers per container
+- number of database connections allowed per Flask app
+- number of containers
+
+However, this is likely to expand.
+
+## Getting started
+
+There's a Makefile that includes all the commands that are needed to get going.
+
+1. ```make build``` to build and star the docker containers
+2. ```make test``` to run k6 against the environment
+
+
+## Caveats
+
+Load balancing between multiple docker containers running the Flask app currently only works with 1 or 2 containers. The likely reason for this is docker embedded DNS, which causes some of the container IP addresses to just not be used by k6.
+
+If this needs to be corrected and more than2 replicas of the Flask app are needed, manually copy the flask app service block, increment the service name, and then manually add entries to the nginx.conf file.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ There's a Makefile that includes all the commands that are needed to get going.
 1. ```make build``` to build and star the docker containers
 2. ```make test``` to run k6 against the environment
 
+It is possible encouraged to monitor resource usage with the ```docker stats``` command to ensure that containers are being loaded appropriately.
 
 ## Caveats
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,28 @@
 services:
+
+  nginx:
+    image: nginx:latest
+    container_name: nginx
+    ports:
+      - "5000:5000"  # Expose on localhost
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf
+    networks:
+      - worker_experimentation_network
+
   flask-app:
     build: .
-    ports:
-      - "5000:5000"
-    container_name: flask-app
-    # Resource limits
+    expose:
+      - "5000"
     deploy:
+      replicas: 2
+      #endpoint_mode: dnsrr
       resources:
         limits:
-          cpus: "1.0"         # Limit to 1 CPUs
-          memory: "2G"       # Limit to 2 GiB of memory
+          cpus: "1.0"
+          memory: "2G"
+    networks:
+      - worker_experimentation_network
     volumes:
       - ./requirements.txt:/app/requirements.txt
     command: >
@@ -21,11 +34,17 @@ services:
     ports:
       - "3306:3306"
     environment:
-      MYSQL_ROOT_PASSWORD: strong_password     
+      MYSQL_ROOT_PASSWORD: strong_password
+    networks:
+      - worker_experimentation_network
     volumes:
       - mysql-data:/var/lib/mysql
       - ./init.sql:/docker-entrypoint-initdb.d/init.sql
-      - ./mysql/my.cnf:/etc/mysql/my.cnf 
+      - ./mysql/my.cnf:/etc/mysql/my.cnf
 
 volumes:
   mysql-data:
+
+networks:
+  worker_experimentation_network:
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,11 +8,8 @@ services:
     deploy:
       resources:
         limits:
-          cpus: "2.0"         # Limit to 1 CPUs
+          cpus: "1.0"         # Limit to 1 CPUs
           memory: "2G"       # Limit to 2 GiB of memory
-        reservations:
-          cpus: "2.0"         # Reserve 1 CPU for the app
-          memory: "1G"       # Reserve 1 GiB of memory for the app
     volumes:
       - ./requirements.txt:/app/requirements.txt
     command: >
@@ -24,15 +21,7 @@ services:
     ports:
       - "3306:3306"
     environment:
-      MYSQL_ROOT_PASSWORD: strong_password
-    deploy:
-      resources:
-        limits:
-          cpus: "10.0"         
-          memory: "10G"       
-        reservations:
-          cpus: "9.0"         
-          memory: "10G"       
+      MYSQL_ROOT_PASSWORD: strong_password     
     volumes:
       - mysql-data:/var/lib/mysql
       - ./init.sql:/docker-entrypoint-initdb.d/init.sql

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,18 @@
+events {}
+
+http {
+    upstream flask_app {
+        # Resolve all IPs for flask-app replicas
+        server flask-app:5000;
+        
+    }
+
+    server {
+        listen 5000;
+        resolver 127.0.0.11 valid=1s;
+        location / {
+            
+            proxy_pass http://flask_app;
+        }
+    }
+}


### PR DESCRIPTION
- Puts an nginx container in front of the Flask app.
- Runs 2 replicas of the Flask app
- Adds README.md